### PR TITLE
Pin prosody version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ EXPOSE 5000 5222 5223 5269 5280 5281 5347
 RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 107D65A0A148C237FDF00AB47393D7E674D9DBB5 && \
     echo deb http://packages.prosody.im/debian wheezy main >>/etc/apt/sources.list
 
+ENV PROSODY_VERSION 0.9.7-1~wheezy1
+
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y prosody lua-event lua-zlib lua-dbi-mysql lua-dbi-postgresql lua-dbi-sqlite3 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y prosody=${PROSODY_VERSION} lua-event lua-zlib lua-dbi-mysql lua-dbi-postgresql lua-dbi-sqlite3 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Remove SUID programs


### PR DESCRIPTION
This makes it easy to build images with updated versions, as the `apt-get install` command is cached otherwise.
